### PR TITLE
Add basic RGB shape counting pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+target/
+*.png
+selection.json

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "RGB_judge"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+
+tfhe = "0.3"
+rayon = "1.9"
+image = "0.24"
+imageproc = "0.23"
+serde_json = "1.0"

--- a/select_image.py
+++ b/select_image.py
@@ -1,0 +1,46 @@
+# coding: utf-8
+"""select_image.py - Allow user to select rectangle on image and save result
+
+Usage:
+    python3 select_image.py input.jpg selection.json
+
+The script displays the image, allows user to select a rectangular region with the
+mouse. The resulting rectangle will be drawn in red and saved next to the image.
+The coordinates of the rectangle are saved to selection.json.
+"""
+import cv2
+import json
+import sys
+
+
+def main():
+    if len(sys.argv) < 3:
+        print("Usage: python3 select_image.py <input_image> <output_json>")
+        return
+
+    img_path = sys.argv[1]
+    out_json = sys.argv[2]
+
+    img = cv2.imread(img_path)
+    if img is None:
+        print(f"Failed to load {img_path}")
+        return
+
+    # Let user select ROI interactively
+    r = cv2.selectROI("Select Region", img, False, False)
+    x, y, w, h = r
+
+    # Draw red rectangle
+    img_rect = img.copy()
+    cv2.rectangle(img_rect, (x, y), (x + w, y + h), (0, 0, 255), 2)
+    cv2.imshow("Selected", img_rect)
+    cv2.waitKey(0)
+
+    # Save rectangle image and coordinates
+    cv2.imwrite("selected_with_rect.png", img_rect)
+    with open(out_json, 'w') as f:
+        json.dump({'x': int(x), 'y': int(y), 'w': int(w), 'h': int(h)}, f)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/count_rgb.rs
+++ b/src/count_rgb.rs
@@ -1,0 +1,30 @@
+use crate::encrypt_image::EncryptedBlock;
+use tfhe::shortint::{Ciphertext, ClientKey, ServerKey};
+
+/// Count how many pixels in the encrypted image match the reference RGB value.
+/// For simplicity we decrypt each pixel. Real applications would perform
+/// homomorphic comparison instead.
+pub fn count_rgb(
+    blocks: &[EncryptedBlock],
+    ref_rgb: [Ciphertext; 3],
+    client_key: &ClientKey,
+    _server_key: &ServerKey,
+) -> u32 {
+    let ref_vals: Vec<u64> = ref_rgb
+        .iter()
+        .map(|c| client_key.decrypt(c))
+        .collect();
+    let mut count = 0u32;
+    for block in blocks {
+        let mut iter = block.data.iter();
+        while let (Some(r), Some(g), Some(b)) = (iter.next(), iter.next(), iter.next()) {
+            let rv = client_key.decrypt(r);
+            let gv = client_key.decrypt(g);
+            let bv = client_key.decrypt(b);
+            if rv == ref_vals[0] && gv == ref_vals[1] && bv == ref_vals[2] {
+                count += 1;
+            }
+        }
+    }
+    count
+}

--- a/src/count_shape.rs
+++ b/src/count_shape.rs
@@ -1,0 +1,28 @@
+use image::{DynamicImage, GrayImage};
+use imageproc::contours::{find_contours, BorderType, Contour};
+
+/// Detects polygons using contours and returns number of sides for the largest
+/// contour inside the given rectangle.
+fn detect_shape(img: &GrayImage, rect: (u32, u32, u32, u32)) -> usize {
+    let (x, y, w, h) = rect;
+    let sub_image = image::imageops::crop_imm(img, x, y, w, h).to_image();
+    let contours = find_contours::<u8>(&sub_image, BorderType::Outer);
+    contours
+        .iter()
+        .map(Contour::len)
+        .max()
+        .unwrap_or(0)
+}
+
+/// Count shapes with the same number of contour points as the reference shape.
+pub fn count_same_shape(img: &DynamicImage, rect: (u32, u32, u32, u32)) -> u32 {
+    // Convert to grayscale
+    let gray = img.to_luma8();
+    let ref_sides = detect_shape(&gray, rect);
+    // Find contours on full image
+    let contours = find_contours::<u8>(&gray, BorderType::Outer);
+    contours
+        .iter()
+        .filter(|c| c.len() == ref_sides)
+        .count() as u32
+}

--- a/src/encrypt_image.rs
+++ b/src/encrypt_image.rs
@@ -1,0 +1,53 @@
+use image::{DynamicImage, GenericImageView};
+use rayon::prelude::*;
+use tfhe::prelude::*;
+use tfhe::shortint::{Ciphertext, ClientKey, ConfigBuilder, ServerKey};
+
+/// Structure holding the encrypted blocks
+pub struct EncryptedBlock {
+    pub data: Vec<Ciphertext>,
+}
+
+/// Encrypt the image using TFHE and return encrypted blocks.
+/// The image is divided into blocks of `block_size` pixels.
+/// The last blocks on the edges may be smaller if the image size is not
+/// a multiple of `block_size`.
+pub fn encrypt_image(
+    img: &DynamicImage,
+    block_size: u32,
+    client_key: &ClientKey,
+) -> Vec<EncryptedBlock> {
+    let (width, height) = img.dimensions();
+    // Iterate over blocks in parallel
+    let blocks: Vec<EncryptedBlock> = (0..height)
+        .step_by(block_size as usize)
+        .flat_map(|y| {
+            (0..width)
+                .step_by(block_size as usize)
+                .map(move |x| (x, y))
+        })
+        .collect::<Vec<_>>()
+        .into_par_iter()
+        .map(|(x, y)| {
+            let mut block_pixels = Vec::new();
+            for j in y..(y + block_size).min(height) {
+                for i in x..(x + block_size).min(width) {
+                    let pixel = img.get_pixel(i, j);
+                    for c in pixel.0 {
+                        block_pixels.push(client_key.encrypt(u64::from(c)));
+                    }
+                }
+            }
+            EncryptedBlock { data: block_pixels }
+        })
+        .collect();
+    blocks
+}
+
+/// Simple helper to create TFHE keys
+pub fn create_keys() -> (ClientKey, ServerKey) {
+    let config = ConfigBuilder::all_disabled().enable_default_uint4().build();
+    let client_key = ClientKey::generate(config);
+    let server_key = ServerKey::generate(&client_key);
+    (client_key, server_key)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,68 @@
+use std::fs::File;
+use std::io::Read;
+use std::process::Command;
+
+use image::GenericImageView;
+
+mod encrypt_image;
+use serde_json;
+mod count_rgb;
+mod count_shape;
+use encrypt_image::{create_keys, encrypt_image};
+use count_rgb::count_rgb;
+use count_shape::count_same_shape;
+
+fn main() {
+    // Parse arguments
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() < 2 {
+        eprintln!("Usage: cargo run -- <image_path> [block_size]");
+        return;
+    }
+    let img_path = &args[1];
+    let block_size: u32 = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(10);
+
+    // Call Python script for region selection
+    let _ = Command::new("python3")
+        .arg("select_image.py")
+        .arg(img_path)
+        .arg("selection.json")
+        .status()
+        .expect("failed to run python script");
+
+    // Read selection
+    let mut file = File::open("selection.json").expect("selection.json missing");
+    let mut buf = String::new();
+    file.read_to_string(&mut buf).unwrap();
+    let sel: serde_json::Value = serde_json::from_str(&buf).unwrap();
+    let x = sel["x"].as_u64().unwrap() as u32;
+    let y = sel["y"].as_u64().unwrap() as u32;
+    let w = sel["w"].as_u64().unwrap() as u32;
+    let h = sel["h"].as_u64().unwrap() as u32;
+
+    let img = image::open(img_path).expect("cannot open image");
+    let (client_key, server_key) = create_keys();
+
+    // Encrypt image
+    let blocks = encrypt_image(&img, block_size, &client_key);
+
+    // Reference color (top-left pixel of selected region)
+    let ref_pixel = img.get_pixel(x, y);
+    let ref_rgb = [
+        client_key.encrypt(u64::from(ref_pixel[0])),
+        client_key.encrypt(u64::from(ref_pixel[1])),
+        client_key.encrypt(u64::from(ref_pixel[2])),
+    ];
+
+    let rgb_count = count_rgb(&blocks, ref_rgb, &client_key, &server_key);
+    let shape_count = count_same_shape(&img, (x, y, w, h));
+
+    println!(
+        "画像の中に、ユーザが選択した物体と同じRGB値の物体は{}個含まれています",
+        rgb_count
+    );
+    println!(
+        "この画像の中に、ユーザが指定した物体と同じ形のものは{}個含まれています",
+        shape_count
+    );
+}


### PR DESCRIPTION
## Summary
- add Python script for interactive ROI selection
- set up Rust project with TFHE-based image encryption example
- implement RGB counting and shape counting modules
- call Python selector from Rust main

## Testing
- `cargo check` *(fails: network access required for crates)*

------
https://chatgpt.com/codex/tasks/task_e_685a3ed9c39083318ff032429bdc71b3