### PR TITLE
Fix compilation with shortint feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+target/
+*.png
+selection.json

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "RGB_judge"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+
+tfhe = { version = "0.5", features = ["shortint"] }
+rayon = "1.9"
+image = "0.24"
+imageproc = "0.23"
+serde_json = "1.0"

--- a/select_image.py
+++ b/select_image.py
@@ -1,0 +1,46 @@
+# coding: utf-8
+"""select_image.py - Allow user to select rectangle on image and save result
+
+Usage:
+    python3 select_image.py input.jpg selection.json
+
+The script displays the image, allows user to select a rectangular region with the
+mouse. The resulting rectangle will be drawn in red and saved next to the image.
+The coordinates of the rectangle are saved to selection.json.
+"""
+import cv2
+import json
+import sys
+
+
+def main():
+    if len(sys.argv) < 3:
+        print("Usage: python3 select_image.py <input_image> <output_json>")
+        return
+
+    img_path = sys.argv[1]
+    out_json = sys.argv[2]
+
+    img = cv2.imread(img_path)
+    if img is None:
+        print(f"Failed to load {img_path}")
+        return
+
+    # Let user select ROI interactively
+    r = cv2.selectROI("Select Region", img, False, False)
+    x, y, w, h = r
+
+    # Draw red rectangle
+    img_rect = img.copy()
+    cv2.rectangle(img_rect, (x, y), (x + w, y + h), (0, 0, 255), 2)
+    cv2.imshow("Selected", img_rect)
+    cv2.waitKey(0)
+
+    # Save rectangle image and coordinates
+    cv2.imwrite("selected_with_rect.png", img_rect)
+    with open(out_json, 'w') as f:
+        json.dump({'x': int(x), 'y': int(y), 'w': int(w), 'h': int(h)}, f)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/count_rgb.rs
+++ b/src/count_rgb.rs
@@ -1,0 +1,66 @@
+use crate::encrypt_image::EncryptedImage;
+use tfhe::shortint::prelude::*;
+
+/// Internal: run connected component labeling on a boolean image.
+fn ccl(width: u32, height: u32, map: &[bool]) -> u32 {
+    let mut visited = vec![false; map.len()];
+    let mut count = 0u32;
+    let dirs = [(1i32, 0i32), (-1, 0), (0, 1), (0, -1)];
+    for y in 0..height {
+        for x in 0..width {
+            let idx = (y * width + x) as usize;
+            if map[idx] && !visited[idx] {
+                count += 1;
+                let mut stack = vec![idx];
+                while let Some(cur) = stack.pop() {
+                    if visited[cur] { continue; }
+                    visited[cur] = true;
+                    let cx = (cur as u32) % width;
+                    let cy = (cur as u32) / width;
+                    for (dx, dy) in dirs.iter() {
+                        let nx = cx as i32 + dx;
+                        let ny = cy as i32 + dy;
+                        if nx >= 0 && ny >= 0 && nx < width as i32 && ny < height as i32 {
+                            let nidx = (ny as u32 * width + nx as u32) as usize;
+                            if map[nidx] && !visited[nidx] {
+                                stack.push(nidx);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    count
+}
+
+/// Count how many objects (connected components) in the encrypted image match
+/// the reference RGB value.
+/// RGB comparison is performed homomorphically and then a plain CCL step
+/// groups adjacent matching pixels.
+pub fn count_rgb_objects(
+    enc_img: &EncryptedImage,
+    ref_rgb: [Ciphertext; 3],
+    client_key: &ClientKey,
+    server_key: &ServerKey,
+) -> u32 {
+    // 1. equality check for each pixel in the encrypted domain
+    let mut eq_pixels = Vec::with_capacity((enc_img.width * enc_img.height) as usize);
+    for px in enc_img.data.chunks(3) {
+        let r = server_key.equal(&px[0], &ref_rgb[0]);
+        let g = server_key.equal(&px[1], &ref_rgb[1]);
+        let b = server_key.equal(&px[2], &ref_rgb[2]);
+        let rg = server_key.bitand(&r, &g);
+        let rgb = server_key.bitand(&rg, &b);
+        eq_pixels.push(rgb);
+    }
+
+    // 2. decrypt boolean map
+    let bool_map: Vec<bool> = eq_pixels
+        .iter()
+        .map(|c| client_key.decrypt(c) != 0)
+        .collect();
+
+    // 3. connected component labeling on plaintext boolean map
+    ccl(enc_img.width, enc_img.height, &bool_map)
+}

--- a/src/count_shape.rs
+++ b/src/count_shape.rs
@@ -1,0 +1,51 @@
+use image::{DynamicImage, GrayImage};
+use imageproc::contours::find_contours;
+use tfhe::shortint::prelude::*;
+
+/// Detects polygons using contours and returns number of sides for the largest
+/// contour inside the given rectangle.
+fn detect_shape(img: &GrayImage, rect: (u32, u32, u32, u32)) -> usize {
+    let (x, y, w, h) = rect;
+    let sub_image = image::imageops::crop_imm(img, x, y, w, h).to_image();
+    let contours = find_contours::<u8>(&sub_image);
+    contours
+        .iter()
+        .map(|c| c.points.len())
+        .max()
+        .unwrap_or(0)
+}
+
+/// Count shapes with the same number of contour points as the reference shape.
+pub fn count_same_shape(img: &DynamicImage, rect: (u32, u32, u32, u32)) -> u32 {
+    // Plaintext version kept for comparison
+    let gray = img.to_luma8();
+    let ref_sides = detect_shape(&gray, rect);
+    let contours = find_contours::<u8>(&gray);
+    contours
+        .iter()
+        .filter(|c| c.points.len() == ref_sides)
+        .count() as u32
+}
+
+/// Attempt to count shapes homomorphically by comparing contour length.
+/// Only the comparison and accumulation are done under FHE to keep the
+/// example simple.
+pub fn count_same_shape_fhe(
+    img: &DynamicImage,
+    rect: (u32, u32, u32, u32),
+    client_key: &ClientKey,
+    server_key: &ServerKey,
+) -> u32 {
+    let gray = img.to_luma8();
+    let ref_sides = detect_shape(&gray, rect) as u64;
+    let ref_ct = client_key.encrypt(ref_sides);
+    let mut count_ct = client_key.encrypt(0u64);
+    let contours = find_contours::<u8>(&gray);
+    for c in contours {
+        let len_ct = client_key.encrypt(c.points.len() as u64);
+        let eq = server_key.equal(&len_ct, &ref_ct);
+        count_ct = server_key.add(&count_ct, &eq);
+    }
+    client_key.decrypt(&count_ct) as u32
+}
+

--- a/src/encrypt_image.rs
+++ b/src/encrypt_image.rs
@@ -1,0 +1,101 @@
+use image::{DynamicImage, GenericImageView};
+use rayon::prelude::*;
+use tfhe::shortint::prelude::*;
+use tfhe::shortint::parameters::PARAM_MESSAGE_1_CARRY_1_KS_PBS;
+use tfhe::shortint::gen_keys;
+
+/// Structure holding the encrypted blocks.
+/// Each block remembers its position within the original image so
+/// that the blocks can later be merged back into a full image.
+#[derive(Clone)]
+pub struct EncryptedBlock {
+    pub x: u32,
+    pub y: u32,
+    pub width: u32,
+    pub height: u32,
+    pub data: Vec<Ciphertext>,
+}
+
+/// Encrypted image reconstructed from individual blocks.
+pub struct EncryptedImage {
+    pub width: u32,
+    pub height: u32,
+    pub data: Vec<Ciphertext>, // RGB data flattened row major
+}
+
+/// Encrypt the image using TFHE and return encrypted blocks.
+/// The image is divided into blocks of `block_size` pixels.
+/// The last blocks on the edges may be smaller if the image size is not
+/// a multiple of `block_size`.
+pub fn encrypt_image(
+    img: &DynamicImage,
+    block_size: u32,
+    client_key: &ClientKey,
+) -> Vec<EncryptedBlock> {
+    let (width, height) = img.dimensions();
+    // Iterate over blocks in parallel
+    let blocks: Vec<EncryptedBlock> = (0..height)
+        .step_by(block_size as usize)
+        .flat_map(|y| {
+            (0..width)
+                .step_by(block_size as usize)
+                .map(move |x| (x, y))
+        })
+        .collect::<Vec<_>>()
+        .into_par_iter()
+        .map(|(x, y)| {
+            let mut block_pixels = Vec::new();
+            let h = (y + block_size).min(height) - y;
+            let w = (x + block_size).min(width) - x;
+            for j in 0..h {
+                for i in 0..w {
+                    let pixel = img.get_pixel(x + i, y + j);
+                    for c in pixel.0 {
+                        block_pixels.push(client_key.encrypt(u64::from(c)));
+                    }
+                }
+            }
+            EncryptedBlock {
+                x,
+                y,
+                width: w,
+                height: h,
+                data: block_pixels,
+            }
+        })
+        .collect();
+    blocks
+}
+
+/// Merge encrypted blocks back into a single encrypted image so that
+/// higher level algorithms can operate on the original 2D layout.
+pub fn merge_encrypted_blocks(
+    blocks: &[EncryptedBlock],
+    width: u32,
+    height: u32,
+    client_key: &ClientKey,
+) -> EncryptedImage {
+    // Create a zero ciphertext as initial value for all pixels
+    let zero = client_key.encrypt(0u64);
+    let mut data = vec![zero; (width * height * 3) as usize];
+
+    for block in blocks {
+        for by in 0..block.height {
+            for bx in 0..block.width {
+                let img_x = block.x + bx;
+                let img_y = block.y + by;
+                let src_off = ((by * block.width + bx) * 3) as usize;
+                let dst_off = ((img_y * width + img_x) * 3) as usize;
+                data[dst_off..dst_off + 3]
+                    .clone_from_slice(&block.data[src_off..src_off + 3]);
+            }
+        }
+    }
+
+    EncryptedImage { width, height, data }
+}
+
+/// Simple helper to create TFHE keys
+pub fn create_keys() -> (ClientKey, ServerKey) {
+    gen_keys(PARAM_MESSAGE_1_CARRY_1_KS_PBS)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,72 @@
+use std::fs::File;
+use std::io::Read;
+use std::process::Command;
+
+use image::GenericImageView;
+
+mod encrypt_image;
+use serde_json;
+mod count_rgb;
+mod count_shape;
+use encrypt_image::{create_keys, encrypt_image, merge_encrypted_blocks};
+use count_rgb::count_rgb_objects;
+use count_shape::count_same_shape_fhe;
+
+fn main() {
+    // Parse arguments
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() < 2 {
+        eprintln!("Usage: cargo run -- <image_path> [block_size]");
+        return;
+    }
+    let img_path = &args[1];
+    let block_size: u32 = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(10);
+
+    // Call Python script for region selection
+    let _ = Command::new("python3")
+        .arg("select_image.py")
+        .arg(img_path)
+        .arg("selection.json")
+        .status()
+        .expect("failed to run python script");
+
+    // Read selection
+    let mut file = File::open("selection.json").expect("selection.json missing");
+    let mut buf = String::new();
+    file.read_to_string(&mut buf).unwrap();
+    let sel: serde_json::Value = serde_json::from_str(&buf).unwrap();
+    let x = sel["x"].as_u64().unwrap() as u32;
+    let y = sel["y"].as_u64().unwrap() as u32;
+    let w = sel["w"].as_u64().unwrap() as u32;
+    let h = sel["h"].as_u64().unwrap() as u32;
+
+    let img = image::open(img_path).expect("cannot open image");
+    let (client_key, server_key) = create_keys();
+
+    // Encrypt image in blocks
+    let blocks = encrypt_image(&img, block_size, &client_key);
+    // Merge blocks back into full encrypted image for analysis
+    let enc_img = merge_encrypted_blocks(&blocks, img.width(), img.height(), &client_key);
+
+    // Reference color (center pixel of selected region)
+    let cx = x + w / 2;
+    let cy = y + h / 2;
+    let ref_pixel = img.get_pixel(cx, cy);
+    let ref_rgb = [
+        client_key.encrypt(u64::from(ref_pixel[0])),
+        client_key.encrypt(u64::from(ref_pixel[1])),
+        client_key.encrypt(u64::from(ref_pixel[2])),
+    ];
+
+    let rgb_count = count_rgb_objects(&enc_img, ref_rgb, &client_key, &server_key);
+    let shape_count = count_same_shape_fhe(&img, (x, y, w, h), &client_key, &server_key);
+
+    println!(
+        "画像の中に、ユーザが選択した物体と同じRGB値の物体は{}個含まれています",
+        rgb_count
+    );
+    println!(
+        "この画像の中に、ユーザが指定した物体と同じ形のものは{}個含まれています",
+        shape_count
+    );
+}


### PR DESCRIPTION
## Summary
- enable `shortint` feature for the tfhe crate
- update imports and key generation for latest tfhe APIs
- fix encrypted RGB and shape counting implementations

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_685a3ed9c39083318ff032429bdc71b3